### PR TITLE
Fixed denormalization of array containing id = null

### DIFF
--- a/Serializer/EntityProvider.php
+++ b/Serializer/EntityProvider.php
@@ -88,8 +88,8 @@ class EntityProvider
             throw new UnexpectedValueException('Unable to denormalize data from unknown format');
         }
 
-        // If the id is set, don't even look for the identifier
-        if (array_key_exists('id', $data)) {
+        // If the id is set (and not null), don't even look for the identifier
+        if (isset($data['id'])) {
             return $repository->find($data['id']);
         }
 


### PR DESCRIPTION
Should be considered as if there is no id, instead of looking for an entity with id=null