### PR TITLE
Fixed duplicated denormalized entities that were using the same id

### DIFF
--- a/Resources/config/services/serializer.yml
+++ b/Resources/config/services/serializer.yml
@@ -12,3 +12,5 @@ services:
         class: Sidus\EAVModelBundle\Serializer\EntityProvider
         arguments:
             - '@doctrine'
+        tags:
+            - { name: doctrine.event_listener, event: postFlush }


### PR DESCRIPTION
Example: if you denormalize 
```
entity:
    subentity1:
        id: 123
    subentity2:
        id: 123
```
the subentity `123` may have been created twice ; this patch aims to fix it