### PR TITLE
fix autowiring error

### DIFF
--- a/DependencyInjection/SidusEAVModelExtension.php
+++ b/DependencyInjection/SidusEAVModelExtension.php
@@ -123,7 +123,7 @@ class SidusEAVModelExtension extends Extension
     protected function addFamilyServiceDefinition($code, $familyConfiguration, ContainerBuilder $container)
     {
         $definition = new Definition(
-            new Parameter('sidus_eav_model.family.class'),
+            $container->getParameter('sidus_eav_model.family.class'),
             [
                 $code,
                 new Reference('sidus_eav_model.attribute.registry'),


### PR DESCRIPTION
Get the value of the parameter instead of use the parameter object in service definition