### PR TITLE
Added a caster for EAV entities to cleanup the dump() util

### DIFF
--- a/Debug/EAVDataCaster.php
+++ b/Debug/EAVDataCaster.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sidus\EAVModelBundle\Debug;
+
+
+use Sidus\EAVModelBundle\Entity\DataInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+class EAVDataCaster
+{
+
+    /** @var NormalizerInterface */
+    protected $normalizer;
+
+    /**
+     * DataCaster constructor.
+     *
+     * @param NormalizerInterface $normalizer
+     */
+    public function __construct(NormalizerInterface $normalizer)
+    {
+        $this->normalizer = $normalizer;
+    }
+
+    public function castDataInterface(DataInterface $data, array $a, Stub $stub, $isNested, $filter)
+    {
+        $normalizedData = $this->normalizer->normalize(
+            $data,
+            'json'
+        );
+
+        return $normalizedData;
+    }
+}

--- a/DependencyInjection/DebugCompilerPass.php
+++ b/DependencyInjection/DebugCompilerPass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Sidus\EAVModelBundle\DependencyInjection;
+
+
+use Sidus\EAVModelBundle\Debug\EAVDataCaster;
+use Sidus\EAVModelBundle\Entity\DataInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class DebugCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $container->getDefinition('var_dumper.cloner')->addMethodCall('addCasters', [
+            [DataInterface::class => [new Reference(EAVDataCaster::class), 'castDataInterface']],
+        ]);
+    }
+
+}

--- a/Resources/config/services/debug.yml
+++ b/Resources/config/services/debug.yml
@@ -5,3 +5,7 @@ services:
             - '@Sidus\EAVModelBundle\Registry\AttributeTypeRegistry'
         tags:
             - { name: data_collector, id: sidus_eav_model, template: "@SidusEAVModel/Profiler/sidus_eav_model.html.twig" }
+
+    Sidus\EAVModelBundle\Debug\EAVDataCaster:
+        class: Sidus\EAVModelBundle\Debug\EAVDataCaster
+        autowire: true

--- a/SidusEAVModelBundle.php
+++ b/SidusEAVModelBundle.php
@@ -11,6 +11,7 @@
 namespace Sidus\EAVModelBundle;
 
 use Sidus\BaseBundle\DependencyInjection\Compiler\GenericCompilerPass;
+use Sidus\EAVModelBundle\DependencyInjection\DebugCompilerPass;
 use Sidus\EAVModelBundle\Registry\AttributeRegistry;
 use Sidus\EAVModelBundle\Registry\AttributeTypeRegistry;
 use Sidus\EAVModelBundle\Registry\FamilyRegistry;
@@ -50,5 +51,7 @@ class SidusEAVModelBundle extends Bundle
                 'addFamily'
             )
         );
+
+        $container->addCompilerPass(new DebugCompilerPass());
     }
 }


### PR DESCRIPTION
TODO
* cleanup code
* see if we can use a better caster than normalizer ?

Source: https://symfony.com/doc/current/components/var_dumper/advanced.html#casters