### PR TITLE
Denormalize with a wrong ID throw some null pointer exception later => trigger a real error

### DIFF
--- a/Serializer/Denormalizer/EAVDataDenormalizer.php
+++ b/Serializer/Denormalizer/EAVDataDenormalizer.php
@@ -123,6 +123,9 @@ class EAVDataDenormalizer implements DenormalizerInterface, DenormalizerAwareInt
         unset($context['family'], $context['family_code'], $context['familyCode']); // Removing family info from context
 
         $entity = $this->entityProvider->getEntity($family, $data, $this->nameConverter);
+        if (!$entity instanceof DataInterface) {
+            throw new \UnexpectedValueException('Entity should be a DataInterface');
+        }
 
         if ($entity instanceof ContextualDataInterface
             && isset($context['context'])


### PR DESCRIPTION
This is just to avoid some weird error during the loop later : 
```Type error: Argument 3 passed to Sidus\EAVModelBundle\Serializer\Denormalizer\EAVDataDenormalizer::handleAttributeValue() must implement interface Sidus\EAVModelBundle\Entity\DataInterface, null given, called in /var/www/current/vendor/sidus/eav-model-bundle/Serializer/Denormalizer/EAVDataDenormalizer.php on line 154```