### PR TITLE
Fix cloning did not correctly apply all previous values

### DIFF
--- a/Entity/AbstractData.php
+++ b/Entity/AbstractData.php
@@ -874,8 +874,7 @@ abstract class AbstractData implements ContextualDataInterface
         $this->__construct($this->getFamily());
 
         foreach ($newValues as $newValue) {
-            $this->values->add($newValue);
-            $newValue->setData($this);
+            $this->addValue($newValue);
         }
     }
 


### PR DESCRIPTION
## Issue

With a full CDM, using a "clone" action on an entity (with possibly embedded data) did not copied _all_ values (only a subset...).

## Solution

Still not sure why it works, but using `\Sidus\EAVModelBundle\Entity\AbstractData::addValue` helped...

After this change there was a second error in admin, from a twig template `vendor/cleverage/eav-manager/LayoutBundle/Resources/views/Form/form.fields.html.twig:184`, because the embedded data did not have an id. I removed the "clone embedded data" behaviour from `\Sidus\EAVModelBundle\Entity\AbstractValue::__clone` because
* it couldn't work in admin as-is
* I'm not sure it's always a desired behaviour... (at least for me it's not I believe) maybe it should be a dedicated attribute option ?

This last change could be a breaking one.